### PR TITLE
Fix Equals for ColorData 

### DIFF
--- a/Engine/Data/ColorData.cs
+++ b/Engine/Data/ColorData.cs
@@ -199,9 +199,9 @@ namespace PixelVisionSDK
         
         public override bool Equals(object other)
         {
-            if (!(other is ColorData))
+            if (!(other is IColor))
                 return false;
-            ColorData color = (ColorData) other;
+            var color = (IColor)other;
             return this.r.Equals(color.r) && this.g.Equals(color.g) && this.b.Equals(color.b) && this.a.Equals(color.a);
         }
 


### PR DESCRIPTION
The ColorData Equals override is being used in the SpriteParser here: https://github.com/PixelVision8/SDK/blob/master/Runner/Parsers/SpriteParser.cs#L219 to find the appropriate color index when loading a Sprite.

The problem is that ColorData is being compared against another IColor (MonoGame adapted Color) and not another ColorData so this always fails when it drops into the Equals and does the type check on line 202. Since ColorData implements IColor, the way I have solved the problem is to make ColorData comparable to any class implementing the IColor interface.

Another way to solve this is to change the SpriteParser to use ColorData exclusively and immediately transform IColor instances into ColorData instances or use a different method to find the color within the array.

This modification is required to get the MonoGameRunner functioning.

I posted to a branch directly on the repo. Let me know if you would rather have me submit a PR from a fork in the future.